### PR TITLE
Allow types to implement BeforeSave method that will be called before inserting data to database

### DIFF
--- a/fixtures.go
+++ b/fixtures.go
@@ -11,6 +11,7 @@
 package fixtures
 
 import (
+	"context"
 	"log"
 	"reflect"
 
@@ -26,6 +27,11 @@ type defaultLogger struct{}
 
 func (l defaultLogger) Warn(msg string) {
 	log.Println(msg)
+}
+
+// BeforeSave interface can be implemented by a type to allow changing type data before saving data to database.
+type BeforeSave interface {
+	BeforeSave(context.Context) error
 }
 
 // Repsitory of fixtures that can be loaded and imported.

--- a/samples_test.go
+++ b/samples_test.go
@@ -1,6 +1,8 @@
 package fixtures
 
 import (
+	"context"
+	"strings"
 	"time"
 )
 
@@ -37,4 +39,10 @@ type Transaction struct {
 type Address struct {
 	ID   int
 	City string
+}
+
+func (a *Address) BeforeSave(_ context.Context) error {
+	a.City = strings.TrimSpace(a.City)
+
+	return nil
 }

--- a/source.go
+++ b/source.go
@@ -164,6 +164,11 @@ func (r *Repository) importData(ctx context.Context, db rel.Repository, data map
 			}
 
 			for _, v := range data[table] {
+				if t, ok := v.(BeforeSave); ok {
+					if err := t.BeforeSave(ctx); err != nil {
+						return err
+					}
+				}
 				if err := db.Insert(ctx, v); err != nil {
 					return err
 				}

--- a/testdata/sample/addresses.yaml
+++ b/testdata/sample/addresses.yaml
@@ -1,5 +1,5 @@
 ---
 - id: 1
-  city: New York
+  city: "New York    "
 - id: 2
   city: Michigan


### PR DESCRIPTION
Allows setting default values or specifying plaintext passwords in fixtures that could be encrypted in BeforeSave method